### PR TITLE
Adding Azure CI and CMake & Catkin Package Clean-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,13 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   topic_tools
+  ros_type_introspection
 )
 
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
+find_package(azure_c_shared_utility REQUIRED)
+find_package(azure_iot_sdks REQUIRED)
+find_package(umqtt REQUIRED)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -123,7 +125,7 @@ catkin_package(
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
-  ${catkin_INCLUDE_DIRS}/azure_iot_hub
+  ${IOTHUB_CLIENT_INCLUDES}
 )
 
 ## Declare a C++ library
@@ -156,22 +158,8 @@ link_directories(${catkin_LIBRARY_DIRS})
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node
    ${catkin_LIBRARIES}
-   C:/opt/rosdeps/x64/lib/aziotsharedutil.lib
-   C:/opt/rosdeps/x64/lib/iothub_client.lib
-   C:/opt/rosdeps/x64/lib/parson.lib
-   C:/opt/rosdeps/x64/lib/hsm_security_client.lib
-   C:/opt/rosdeps/x64/lib/prov_auth_client.lib
-   C:/opt/rosdeps/x64/lib/iothub_client_mqtt_transport.lib
-   C:/opt/rosdeps/x64/lib/iothub_client_mqtt_ws_transport.lib
-   C:/opt/rosdeps/x64/lib/uhttp.lib
-   C:/opt/rosdeps/x64/lib/umqtt.lib
-   C:/opt/rosdeps/x64/lib/ros_type_introspection.lib
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/WS2_32.lib"
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/Secur32.lib"
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/Rpcrt4.lib"
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/Winhttp.lib"
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/Ncrypt.lib"
-   "C:/Program Files (x86)/Windows Kits/10/Lib/10.0.17134.0/um/x64/Crypt32.lib"
+   iothub_client
+   iothub_client_mqtt_ws_transport
 )
 
 #############

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,3 +9,7 @@ jobs:
 - template: build.yml@templates  # Template reference
   parameters:
     ros_metapackage: 'ros-melodic-ros_core'
+    pre_build:
+      - script: |
+        git clone https://github.com/ms-iot/abseil-cpp -b init_windows
+        git clone https://github.com/ms-iot/ros_type_introspection -b init_windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,9 @@
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: seanyen-msft/rosonwindows_ci
+      endpoint: github
+
+jobs:
+- template: build.yml@templates  # Template reference

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,3 +13,4 @@ jobs:
       - script: |
           git clone https://github.com/ms-iot/abseil-cpp -b init_windows
           git clone https://github.com/ms-iot/ros_type_introspection -b init_windows
+        workingDirectory: '$(Build.ArtifactStagingDirectory)\src'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,3 +7,5 @@ resources:
 
 jobs:
 - template: build.yml@templates  # Template reference
+  parameters:
+    ros_metapackage: 'ros-melodic-ros_core'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,5 +11,5 @@ jobs:
     ros_metapackage: 'ros-melodic-ros_core'
     pre_build:
       - script: |
-        git clone https://github.com/ms-iot/abseil-cpp -b init_windows
-        git clone https://github.com/ms-iot/ros_type_introspection -b init_windows
+          git clone https://github.com/ms-iot/abseil-cpp -b init_windows
+          git clone https://github.com/ms-iot/ros_type_introspection -b init_windows

--- a/package.xml
+++ b/package.xml
@@ -55,7 +55,8 @@
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-
+  <depend>libazure-iot-sdk-c</depend>
+  <depend>ros_type_introspection</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
- **package.xml**: add the dependencies so rosdeps can figure out what package to download.
- **CMakeLists.txt**:
  - use find_package and CMake imported targets to replace the hard-coded lib paths.
  - add ros_type_introspection as dependencies.
- **azure-pipelines.yml**: Add Azure CI script.

There are some corresponding changes in upstream projects. Check out the "init_windows" branches in those two repos:
- https://github.com/ms-iot/abseil-cpp
- https://github.com/ms-iot/ros_type_introspection
